### PR TITLE
feat: add makepkg support for dtk6

### DIFF
--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -1,20 +1,20 @@
 # Maintainer: justforlxz <justforlxz@gmail.com>
-pkgname=dtkgui-git
-pkgver=5.5.22.r8.g6ef1509
+pkgname=dtk6gui-git
+pkgver=6.0.0
 pkgrel=1
-sourcename=dtkgui
+sourcename=dtk6gui
 sourcetars=("$sourcename"_"$pkgver".tar.xz)
 sourcedir="$sourcename"
 pkgdesc='Deepin Toolkit, gui module for DDE look and feel'
 arch=('x86_64' 'aarch64')
-url="https://github.com/linuxdeepin/dtkgui"
+url="https://github.com/linuxdeepin/dtk6gui"
 license=('LGPL3')
-depends=('dtkcore-git' 'dtkcommon-git' 'qt5-svg' 'libqtxdg' 'freeimage' 'librsvg')
+depends=('dtk6core-git' 'dtkcommon-git' 'gcc-libs' 'qt6-base' 'qt6-svg' 'freeimage' 'librsvg')
 # INFO: you can disable freeimage not to support RAW images
 # Then set DTK_DISABLE_EX_IMAGE_FORMAT=OFF
-makedepends=('git' 'qt5-tools' 'gtest' 'gmock' 'ninja' 'cmake' 'doxygen')
-conflicts=('dtkgui')
-provides=('dtkgui')
+makedepends=('git' 'qt6-tools' 'gtest' 'gmock' 'ninja' 'cmake' 'doxygen' 'pkg-config' 'gcc')
+conflicts=('dtk6gui')
+provides=('dtk6gui')
 groups=('deepin-git')
 source=("${sourcetars[@]}")
 sha512sums=('SKIP')
@@ -22,14 +22,17 @@ sha512sums=('SKIP')
 
 build() {
     cd $sourcedir
+    version=$(echo $pkgver | awk -F'[+_~-]' '{print $1}')
     cmake -GNinja \
-    -DMKSPECS_INSTALL_DIR=lib/qt/mkspecs/modules/ \
-    -DBUILD_DOCS=ON \
+    -DMKSPECS_INSTALL_DIR=lib/qt6/mkspecs/modules/ \
+    -DBUILD_DOCS=OFF \
     -DDTK_DISABLE_LIBRSVG=ON \
-    -DQCH_INSTALL_DESTINATION=share/doc/qt \
+    -DDTK_DISABLE_LIBXDG=ON \
+    -DQCH_INSTALL_DESTINATION=share/doc/qt6 \
     -DCMAKE_INSTALL_LIBDIR=lib \
     -DCMAKE_INSTALL_PREFIX=/usr \
-    -DCMAKE_BUILD_TYPE=Release
+    -DCMAKE_BUILD_TYPE=Release \
+    -DDTK_VERSION=$version
     ninja
     # INFO: Another cmake option is DTK_DISABLE_EX_IMAGE_FORMAT
     # If you not want to support RAW images, set it to off

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,8 +34,14 @@ PRIVATE
     Qt${QT_VERSION_MAJOR}::GuiPrivate
     Qt${QT_VERSION_MAJOR}::CorePrivate
     Qt${QT_VERSION_MAJOR}::DBus
-    PkgConfig::librsvg
 )
+
+if(DTK_DISABLE_LIBRSVG)
+    find_package(Qt${QT_VERSION_MAJOR}Svg REQUIRED)
+    target_link_libraries(${LIB_NAME} PRIVATE Qt${QT_VERSION_MAJOR}::Svg)
+else()
+    target_link_libraries(${LIB_NAME} PRIVATE PkgConfig::librsvg)
+endif()
 
 if(NOT DTK_DISABLE_EX_IMAGE_FORMAT AND EX_IMAGE_FORMAT_LIBS_FOUND)
     target_link_libraries(${LIB_NAME} PRIVATE
@@ -79,4 +85,3 @@ set(EnableCov CACHE BOOL OFF)
 if (EnableCov)
     dtk_setup_code_coverage(${LIB_NAME})
 endif()
-


### PR DESCRIPTION
When disable librsvg, we use QtSvg to implement dsvgrenderer. Link
to Qt(5/6)::Svg target.

Log: fix missing link when disable librsvg