### PR TITLE
chore: bump version to 6.0.30

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dtk6gui (6.0.30) unstable; urgency=medium
+
+  * sync: from linuxdeepin/dtkgui
+
+ -- YeShanShan <yeshanshan@uniontech.com>  Thu, 13 Feb 2025 17:14:12 +0800
+
 dtk6gui (6.0.29) unstable; urgency=medium
 
   * 6.0.29


### PR DESCRIPTION
update changelog to 6.0.30