### PR TITLE
chore: bump version to 6.0.35

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+dtk6gui (6.0.35) unstable; urgency=medium
+
+  * sync: from linuxdeepin/dtkgui
+  * sync: from linuxdeepin/dtkgui
+  * sync: from linuxdeepin/dtkgui
+  * sync: from linuxdeepin/dtkgui
+
+ -- YeShanShan <yeshanshan@uniontech.com>  Thu, 08 May 2025 18:50:18 +0800
+
 dtk6gui (6.0.34) unstable; urgency=medium
 
   * sync: from linuxdeepin/dtkgui


### PR DESCRIPTION
update changelog to 6.0.35