### PR TITLE
fix: add security hardening flags to build process

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -2,6 +2,12 @@
 DPKG_EXPORT_BUILDFLAGS = 1
 include /usr/share/dpkg/default.mk
 
+# 安全编译参数
+export DEB_BUILD_MAINT_OPTIONS = hardening=+all
+export DEB_CFLAGS_MAINT_APPEND = -Wall
+export DEB_CXXFLAGS_MAINT_APPEND = -Wall
+export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed -Wl,-z,relro -Wl,-z,now -Wl,-z,noexecstack -Wl,-E
+
 DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 
 VERSION = $(DEB_VERSION_UPSTREAM)


### PR DESCRIPTION
Added security hardening compiler and linker flags to debian/rules file
1. Set DEB_BUILD_MAINT_OPTIONS with hardening=+all
2. Added -Wall warning flag for C/C++ builds
3. Added security-focused linker flags including RELRO, NOW, noexecstack
4. These changes improve binary security by enabling modern protections
against common exploits

fix: 在构建过程中添加安全加固标志

在 debian/rules 文件中添加了安全加固的编译器和链接器标志
1. 设置 DEB_BUILD_MAINT_OPTIONS 为 hardening=+all
2. 为 C/C++ 构建添加 -Wall 警告标志
3. 添加了安全相关的链接器标志包括 RELRO、NOW、noexecstack
4. 这些更改通过启用针对常见漏洞的现代保护机制来提高二进制文件的安全性
