### PR TITLE
fix(tests): fix build for Qt 6.9

### DIFF
--- a/tests/platform-plugin-test/qminimalintegration.cpp
+++ b/tests/platform-plugin-test/qminimalintegration.cpp
@@ -13,8 +13,14 @@
 #include <qpa/qplatformwindow.h>
 #include <qpa/qwindowsysteminterface.h>
 
+#include <QtGlobal>
+
 #include <private/qgenericunixeventdispatcher_p.h>
+#if QT_VERSION >= 0x060900
+#include <private/qdesktopunixservices_p.h>
+#else
 #include <private/qgenericunixservices_p.h>
+#endif
 
 MinimalIntegration::MinimalIntegration(const QStringList &parameters)
 {
@@ -54,7 +60,11 @@ QAbstractEventDispatcher *MinimalIntegration::createEventDispatcher() const
 QPlatformServices *MinimalIntegration::services() const
 {
     if (!m_services)
+#if QT_VERSION >= 0x060900
+        m_services.reset(new QDesktopUnixServices);
+#else
         m_services.reset(new QGenericUnixServices);
+#endif
     return m_services.get();
 }
 


### PR DESCRIPTION
Qt 6.9 renamed <private/qdesktopunixservices_p.h> to <private/qgenericunixservices_p.h>, as well as some of the classes along the same format (QGenericUnixServices => QDesktopUnixServices).

Add a condition test with QT_VERSION to fix build with Qt >= 6.9.